### PR TITLE
Project tooling & stats in command results

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "node",
+            "request": "attach",
+            "name": "Attach to Remote",
+            "address": "127.0.0.1",
+            "port": 9229,
+            "localRoot": "${workspaceFolder}",
+            "remoteRoot": "${workspaceFolder}"
+          }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+  "files.exclude": {
+    "**/.git": true,
+    "**/.svn": true,
+    "**/.hg": true,
+    "**/CVS": true,
+    "**/.DS_Store": true
+  },
+  "search.exclude": {
+    "**/lib": true,
+    "**/bin": true
+  },
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true,
+  "prettier.singleQuote": true,
+  "rewrap.wrappingColumn": 80
+}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,16 @@ Create a symlink to your locally cloned repo:
 $ npm link
 ```
 
+## Debugging
+
+The project ships with a VS Code debug configuration for Node.js. Open the project in VS Code and go to project file you want to debug. Set some breakpoints by clicking on the left side of the line where you’d like the code execution to stop, and in the terminal type:
+
+```
+$ node --inspect-brk <FILE NAME>
+Debugger listening on ws:127.0.0.1:9229/<UUID>
+```
+
+After this, go to the Debug section in VS Code and run the `Attach to Remote` configuration.
 
 ## Maintainers
 

--- a/cli-install-vsix.js
+++ b/cli-install-vsix.js
@@ -21,7 +21,7 @@ const installVsix = (isInsiders, buildNum) => {
       info(`VSIXs to be downloaded : ${jsonData.length}`);
     }
 
-    for (const i in jsonData) {
+    for (let i = 0; i < jsonData.length; i++) {
       const vsixName = getVsixName(jsonData[i]);
       const optsDownload = buildVsixUrl(jsonData[i]);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circleci-to-vscode",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Download artifacts from circle ci and install them as vscode extensions",
   "main": "index.js",
   "scripts": {

--- a/utils/circleci.js
+++ b/utils/circleci.js
@@ -1,5 +1,4 @@
 const url = require('url');
-const { info } = require('./log');
 
 const buildHTTPOpts = (buildNum, config) => {
   // https://circleci.com/docs/2.0/artifacts/#downloading-all-artifacts-for-a-build-on-circleci
@@ -16,12 +15,9 @@ const buildHTTPOpts = (buildNum, config) => {
 };
 
 const getVsixName = data => {
-  const vsixName = data.path
+  return data.path
     .replace('home/circleci/project/extensions/', '')
     .replace('.vsix', '');
-
-  info(`Processing vsix : ${vsixName}`);
-  return vsixName;
 };
 
 const buildVsixUrl = data => {

--- a/utils/vsixStats.js
+++ b/utils/vsixStats.js
@@ -1,0 +1,47 @@
+const chalk = require('chalk');
+const util = require('util');
+
+class VsixStats {
+  constructor() {
+    if (!VsixStats.instance) {
+      // eslint-disable-next-line no-undef
+      this.dataMap = new Map();
+      VsixStats.instance = this;
+    }
+
+    return VsixStats.instance;
+  }
+
+  add(id, item) {
+    if (this.dataMap.has(id)) {
+      const existingValue = this.dataMap.get(id);
+      this.dataMap.set(id, Object.assign(existingValue, item));
+      return;
+    }
+    this.dataMap.set(id, item);
+  }
+
+  get(id) {
+    return this.dataMap.get(id);
+  }
+  /* eslint-disable no-console */
+  printStats(id) {
+    const stats = this.get(id);
+    console.log(chalk.bold.cyan(`Successfully installed extension ${id}`));
+    console.log(
+      `${chalk.bold.cyan('Vsix size :')} ${chalk.bold.yellow(
+        `${stats.vsixSize} MB`
+      )}`
+    );
+
+    const download = stats.downloadTime;
+    console.log(
+      `${chalk.bold.cyan('Download time :')} ${chalk.bold.yellow(
+        `${util.format('%d%d', download[0], download[1] / 1000000)} ms`
+      )}\n`
+    );
+  }
+}
+
+const vsixStats = new VsixStats();
+module.exports = { vsixStats };


### PR DESCRIPTION
Add formatting & debugging configuration using VSCode.
Capture and print vsix size and download time as part of `ctv install <build>` results.